### PR TITLE
Allow opening the DevTools

### DIFF
--- a/lib/webview.dart
+++ b/lib/webview.dart
@@ -97,6 +97,7 @@ class _WinWebViewWidgetState extends State<WinWebViewWidget> {
 // --------------------------------------------------------------------------
 
 int _gLastWebViewId = 0;
+
 class WinWebViewController {
   final _webviewId = ++_gLastWebViewId;
   late Future<bool> _initFuture;
@@ -128,7 +129,8 @@ class WinWebViewController {
     _javaScriptMessageCallbacks[name] = callback;
     if (!isExists) {
       await _initFuture;
-      await WebviewWinFloatingPlatform.instance.addScriptChannelByName(_webviewId, name);
+      await WebviewWinFloatingPlatform.instance
+          .addScriptChannelByName(_webviewId, name);
     }
   }
 
@@ -137,7 +139,8 @@ class WinWebViewController {
     _javaScriptMessageCallbacks.remove(name);
     if (!isExists) {
       await _initFuture;
-      await WebviewWinFloatingPlatform.instance.removeScriptChannelByName(_webviewId, name);
+      await WebviewWinFloatingPlatform.instance
+          .removeScriptChannelByName(_webviewId, name);
     }
   }
 
@@ -374,5 +377,10 @@ class WinWebViewController {
     await _initFuture;
     WebviewWinFloatingPlatform.instance.unregisterWebView(_webviewId);
     await WebviewWinFloatingPlatform.instance.dispose(_webviewId);
+  }
+
+  Future<void> openDevTools() async {
+    await _initFuture;
+    await WebviewWinFloatingPlatform.instance.openDevTools(_webviewId);
   }
 }

--- a/lib/webview_plugin.dart
+++ b/lib/webview_plugin.dart
@@ -267,6 +267,10 @@ class WindowsPlatformWebViewController extends PlatformWebViewController {
   Future<void> setBackgroundColor(Color color) {
     return controller.setBackgroundColor(color);
   }
+
+  Future<void> openDevTools() {
+    return controller.openDevTools();
+  }
 }
 
 // --------------------------------------------------------------------------

--- a/lib/webview_win_floating_method_channel.dart
+++ b/lib/webview_win_floating_method_channel.dart
@@ -66,8 +66,8 @@ class MethodChannelWebviewWinFloating extends WebviewWinFloatingPlatform {
   @override
   Future<bool> create(int webviewId, String? initialUrl) async {
     return await methodChannel.invokeMethod<bool>(
-            'create', {"webviewId": webviewId, "url": initialUrl ?? ""})
-        ?? false;
+            'create', {"webviewId": webviewId, "url": initialUrl ?? ""}) ??
+        false;
   }
 
   @override
@@ -215,5 +215,11 @@ class MethodChannelWebviewWinFloating extends WebviewWinFloatingPlatform {
   @override
   Future<void> dispose(int webviewId) async {
     await methodChannel.invokeMethod<bool>('dispose', {"webviewId": webviewId});
+  }
+
+  @override
+  Future<void> openDevTools(int webviewId) {
+    return methodChannel
+        .invokeMethod<void>('openDevTools', {"webviewId": webviewId});
   }
 }

--- a/lib/webview_win_floating_platform_interface.dart
+++ b/lib/webview_win_floating_platform_interface.dart
@@ -11,7 +11,8 @@ abstract class WebviewWinFloatingPlatform extends PlatformInterface {
 
   static final Object _token = Object();
 
-  static WebviewWinFloatingPlatform _instance = MethodChannelWebviewWinFloating();
+  static WebviewWinFloatingPlatform _instance =
+      MethodChannelWebviewWinFloating();
 
   /// The default instance of [WebviewWinFloatingPlatform] to use.
   ///
@@ -34,12 +35,12 @@ abstract class WebviewWinFloatingPlatform extends PlatformInterface {
     throw UnimplementedError();
   }
 
-
   Future<bool> create(int webviewId, String? initialUrl) {
     throw UnimplementedError();
   }
 
-  Future<void> updateBounds(int webviewId, Offset offset, Size size, double devicePixelRatio) {
+  Future<void> updateBounds(
+      int webviewId, Offset offset, Size size, double devicePixelRatio) {
     throw UnimplementedError();
   }
 
@@ -55,7 +56,8 @@ abstract class WebviewWinFloatingPlatform extends PlatformInterface {
     throw UnimplementedError();
   }
 
-  Future<String> runJavaScriptReturningResult(int webviewId, String javaScriptString) {
+  Future<String> runJavaScriptReturningResult(
+      int webviewId, String javaScriptString) {
     throw UnimplementedError();
   }
 
@@ -124,6 +126,10 @@ abstract class WebviewWinFloatingPlatform extends PlatformInterface {
   }
 
   Future<void> dispose(int webviewId) {
+    throw UnimplementedError();
+  }
+
+  Future<void> openDevTools(int webviewId) {
     throw UnimplementedError();
   }
 }

--- a/test/webview_win_floating_test.dart
+++ b/test/webview_win_floating_test.dart
@@ -70,8 +70,7 @@ class MockWebviewWinFloatingPlatform
   }
 
   @override
-  void registerWebView(int webviewId, WinWebViewController webview) {
-  }
+  void registerWebView(int webviewId, WinWebViewController webview) {}
 
   @override
   Future<void> reload(int webviewId) {
@@ -84,7 +83,8 @@ class MockWebviewWinFloatingPlatform
   }
 
   @override
-  Future<String> runJavaScriptReturningResult(int webviewId, String javaScriptString) {
+  Future<String> runJavaScriptReturningResult(
+      int webviewId, String javaScriptString) {
     throw UnimplementedError();
   }
 
@@ -104,11 +104,11 @@ class MockWebviewWinFloatingPlatform
   }
 
   @override
-  void unregisterWebView(int webviewId) {
-  }
+  void unregisterWebView(int webviewId) {}
 
   @override
-  Future<void> updateBounds(int webviewId, Offset offset, Size size, double devicePixelRatio) {
+  Future<void> updateBounds(
+      int webviewId, Offset offset, Size size, double devicePixelRatio) {
     throw UnimplementedError();
   }
 
@@ -132,10 +132,15 @@ class MockWebviewWinFloatingPlatform
     throw UnimplementedError();
   }
 
+  @override
+  Future<void> openDevTools(int webviewId) {
+    throw UnimplementedError();
+  }
 }
 
 void main() {
-  final WebviewWinFloatingPlatform initialPlatform = WebviewWinFloatingPlatform.instance;
+  final WebviewWinFloatingPlatform initialPlatform =
+      WebviewWinFloatingPlatform.instance;
 
   test('$MethodChannelWebviewWinFloating is the default instance', () {
     expect(initialPlatform, isInstanceOf<MethodChannelWebviewWinFloating>());
@@ -143,7 +148,8 @@ void main() {
 
   test('getPlatformVersion', () async {
     //WebviewWinFloating webviewWinFloatingPlugin = WebviewWinFloating();
-    MockWebviewWinFloatingPlatform fakePlatform = MockWebviewWinFloatingPlatform();
+    MockWebviewWinFloatingPlatform fakePlatform =
+        MockWebviewWinFloatingPlatform();
     WebviewWinFloatingPlatform.instance = fakePlatform;
 
     //expect(await webviewWinFloatingPlugin.getPlatformVersion(), '42');

--- a/windows/my_webview.cpp
+++ b/windows/my_webview.cpp
@@ -74,6 +74,8 @@ public:
     HRESULT clearCache();
     HRESULT clearCookies();
 
+    void openDevTools() override;
+
 private:
     template<class T> wil::com_ptr<T> getProfile();
     std::wstring nowLoadingUrl;
@@ -463,4 +465,9 @@ HRESULT MyWebViewImpl::clearCookies()
     if (cookieManager == NULL) return E_FAIL;
 
     return cookieManager->DeleteAllCookies();
+}
+
+void MyWebViewImpl::openDevTools()
+{
+    m_pWebview->OpenDevToolsWindow();
 }

--- a/windows/my_webview.h
+++ b/windows/my_webview.h
@@ -49,4 +49,6 @@ public:
 
 	virtual HRESULT clearCache() = 0;
 	virtual HRESULT clearCookies() = 0;
+
+	virtual void openDevTools() = 0;
 };

--- a/windows/webview_win_floating_plugin.cpp
+++ b/windows/webview_win_floating_plugin.cpp
@@ -223,6 +223,9 @@ void WebviewWinFloatingPlugin::HandleMethodCall(
       std::cout << "[webview] native dispose: id = " << webviewId << "\n";
     }
     result->Success(flutter::EncodableValue(true));
+  } else if (method_call.method_name().compare("openDevTools") == 0) {
+    webview->openDevTools();
+    result->Success();
   } else {
     result->NotImplemented();
   }


### PR DESCRIPTION
This is a proposition of method that allows opening the DevTools which can be handy while debugging.

Note: You have to use `WinWebViewController()` to be able to use the `openDevTools()` method as it is absent in `plugin_platform_interface/webview_flutter`.


![19_01_2023_11_30_53 -1674124253](https://user-images.githubusercontent.com/119860089/213424396-75b85b5a-5adb-4be1-912e-ad7a364d4e93.gif)


I did small formatting changes in some places because of some differences in formatting settings on my end - wasn't able to find the settings that don't lead to formatting changes.

