### PR TITLE
Add history changed callback

### DIFF
--- a/lib/webview.dart
+++ b/lib/webview.dart
@@ -21,15 +21,18 @@ class WinNavigationDelegate {
 
   final PageTitleChangedCallback? onPageTitleChanged;
   final FullScreenChangedCallback? onFullScreenChanged;
+  final HistoryChangedCallback? onHistoryChanged;
 
-  WinNavigationDelegate(
-      {this.onNavigationRequest,
-      this.onPageStarted,
-      this.onPageFinished,
-      this.onProgress,
-      this.onWebResourceError,
-      this.onPageTitleChanged,
-      this.onFullScreenChanged});
+  WinNavigationDelegate({
+    this.onNavigationRequest,
+    this.onPageStarted,
+    this.onPageFinished,
+    this.onProgress,
+    this.onWebResourceError,
+    this.onPageTitleChanged,
+    this.onFullScreenChanged,
+    this.onHistoryChanged,
+  });
 }
 
 typedef WebViewCreatedCallback = void Function(
@@ -40,6 +43,7 @@ typedef PageTitleChangedCallback = void Function(String title);
 typedef JavaScriptMessageCallback = void Function(JavaScriptMessage message);
 typedef FullScreenChangedCallback = void Function(bool isFullScreen);
 typedef MoveFocusRequestCallback = void Function(bool isNext);
+typedef HistoryChangedCallback = void Function();
 
 class WinWebViewWidget extends StatefulWidget {
   final WinWebViewController controller;
@@ -211,6 +215,12 @@ class WinWebViewController {
     FullScreenWindow.setFullScreen(isFullScreen);
     if (_navigationDelegate?.onFullScreenChanged != null) {
       _navigationDelegate!.onFullScreenChanged!(isFullScreen);
+    }
+  }
+
+  void notifyHistoryChanged_() {
+    if (_navigationDelegate?.onHistoryChanged != null) {
+      _navigationDelegate!.onHistoryChanged!();
     }
   }
 

--- a/lib/webview_win_floating_method_channel.dart
+++ b/lib/webview_win_floating_method_channel.dart
@@ -47,6 +47,8 @@ class MethodChannelWebviewWinFloating extends WebviewWinFloatingPlatform {
         bool? isFullScreen = call.arguments["isFullScreen"];
         assert(isFullScreen != null);
         controller.notifyFullScreenChanged_(isFullScreen!);
+      } else if (call.method == "onHistoryChanged") {
+        controller.notifyHistoryChanged_();
       } else {
         assert(false, "unknown call from native: ${call.method}");
       }

--- a/windows/my_webview.h
+++ b/windows/my_webview.h
@@ -20,7 +20,9 @@ public:
 		std::function<void(std::string)> onPageTitleChanged,
 		std::function<void(std::string)> onWebMessageReceived,
 		std::function<void(bool)> onMoveFocusRequest,
-		std::function<void(bool)> onFullScreenChanged);
+		std::function<void(bool)> onFullScreenChanged,
+		std::function<void()> onHistoryChanged);
+		
 	//MyWebView();
 	virtual ~MyWebView() {};
 

--- a/windows/webview_win_floating_plugin.cpp
+++ b/windows/webview_win_floating_plugin.cpp
@@ -124,7 +124,12 @@ void WebviewWinFloatingPlugin::HandleMethodCall(
       arguments[flutter::EncodableValue("isFullScreen")] = flutter::EncodableValue(isFullScreen ? true : false);
       gMethodChannel->InvokeMethod("OnFullScreenChanged", std::make_unique<flutter::EncodableValue>(arguments));
     };
-    MyWebView::Create(g_NativeHWND, onCreate, onPageStarted, onPageFinished, onPageTitleChanged, onWebMessageReceived, onMoveFocusRequest, onFullScreenChanged);
+    auto onHistoryChanged = [=]() -> void {
+      flutter::EncodableMap arguments;
+      arguments[flutter::EncodableValue("webviewId")] = flutter::EncodableValue(webviewId);
+      gMethodChannel->InvokeMethod("onHistoryChanged", std::make_unique<flutter::EncodableValue>(arguments));
+    };
+    MyWebView::Create(g_NativeHWND, onCreate, onPageStarted, onPageFinished, onPageTitleChanged, onWebMessageReceived, onMoveFocusRequest, onFullScreenChanged, onHistoryChanged);
   } else if (method_call.method_name().compare("updateBounds") == 0) {
     RECT bounds;
     bounds.left = std::get<int>(arguments[flutter::EncodableValue("left")]);


### PR DESCRIPTION
This PR is introducing the possibility of setting up a callback which is called when the browsing history changes. 
Thanks to that e.g we know when to refresh the `goBack/goForward` buttons. 