### PR TITLE
Addd the setStatusBar method

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@ There are some Windows-only API:
 * controller.openDevTools()
 * onHistoryChanged` callback in WinNavigationDelegate
 * controller.dispose()
+* controller.setStatusBar(bool isEnable): show/hide [status bar](https://learn.microsoft.com/en-us/dotnet/api/microsoft.web.webview2.core.corewebview2settings.isstatusbarenabled)
 
 
 # TroubleShooting

--- a/lib/webview_plugin.dart
+++ b/lib/webview_plugin.dart
@@ -157,6 +157,10 @@ class WindowsPlatformWebViewController extends PlatformWebViewController {
     return controller.setJavaScriptMode(javaScriptMode);
   }
 
+  Future<void> setStatusBar(bool isEnable) {
+    return controller.setStatusBar(isEnable);
+  }
+
   @override
   Future<void> addJavaScriptChannel(
       JavaScriptChannelParams javaScriptChannelParams) async {

--- a/lib/webview_plugin.dart
+++ b/lib/webview_plugin.dart
@@ -157,9 +157,6 @@ class WindowsPlatformWebViewController extends PlatformWebViewController {
     return controller.setJavaScriptMode(javaScriptMode);
   }
 
-  Future<void> setStatusBar(bool isEnable) {
-    return controller.setStatusBar(isEnable);
-  }
 
   @override
   Future<void> addJavaScriptChannel(
@@ -281,6 +278,10 @@ class WindowsPlatformWebViewController extends PlatformWebViewController {
 
   Future<void> openDevTools() {
     return controller.openDevTools();
+  }
+
+  Future<void> setStatusBar(bool isEnable) {
+    return controller.setStatusBar(isEnable);
   }
 }
 

--- a/lib/webview_win_floating.dart
+++ b/lib/webview_win_floating.dart
@@ -145,6 +145,12 @@ class WinWebViewController {
         .enableJavascript(_webviewId, isEnable);
   }
 
+  Future<void> setStatusBar(bool isEnable) async {
+    await _initFuture;
+    await WebviewWinFloatingPlatform.instance
+        .enableStatusBar(_webviewId, isEnable);
+  }
+
   Future<void> addJavaScriptChannel(String name,
       {required JavaScriptMessageCallback callback}) async {
     bool isExists = _javaScriptMessageCallbacks.containsKey(name);

--- a/lib/webview_win_floating_method_channel.dart
+++ b/lib/webview_win_floating_method_channel.dart
@@ -172,6 +172,12 @@ class MethodChannelWebviewWinFloating extends WebviewWinFloatingPlatform {
   }
 
   @override
+  Future<void> enableStatusBar(int webviewId, bool isEnable) async {
+    await methodChannel.invokeMethod<bool>(
+        'enableStatusBar', {"webviewId": webviewId, "isEnable": isEnable});
+  }
+
+  @override
   Future<bool> setUserAgent(int webviewId, String userAgent) async {
     bool? b = await methodChannel.invokeMethod<bool?>(
         'setUserAgent', {"webviewId": webviewId, "userAgent": userAgent});

--- a/lib/webview_win_floating_platform_interface.dart
+++ b/lib/webview_win_floating_platform_interface.dart
@@ -86,6 +86,10 @@ abstract class WebviewWinFloatingPlatform extends PlatformInterface {
     throw UnimplementedError();
   }
 
+  Future<void> enableStatusBar(int webviewId, bool isEnable) {
+    throw UnimplementedError();
+  }
+
   Future<bool> setUserAgent(int webviewId, String userAgent) {
     throw UnimplementedError();
   }

--- a/windows/my_webview.cpp
+++ b/windows/my_webview.cpp
@@ -60,6 +60,9 @@ public:
     void removeScriptChannelByName(LPCWSTR channelName);
 
     void enableJavascript(bool bEnable);
+
+    void enableStatusBar(bool bEnable);
+
     HRESULT setUserAgent(LPCWSTR userAgent);
 
     HRESULT updateBounds(RECT& bounds);
@@ -444,6 +447,11 @@ HRESULT MyWebViewImpl::requestFocus(bool isNext)
 void MyWebViewImpl::enableJavascript(bool bEnable)
 {
     m_pSettings->put_IsScriptEnabled(bEnable);
+}
+
+void MyWebViewImpl::enableStatusBar(bool bEnable)
+{
+    m_pSettings->put_IsStatusBarEnabled(bEnable);
 }
 
 HRESULT MyWebViewImpl::setUserAgent(LPCWSTR userAgent)

--- a/windows/my_webview.h
+++ b/windows/my_webview.h
@@ -36,6 +36,8 @@ public:
 	virtual void removeScriptChannelByName(LPCWSTR channelName) = 0;
 
 	virtual void enableJavascript(bool bEnable) = 0;
+	virtual void enableStatusBar(bool bEnable) = 0;
+
 	virtual HRESULT setUserAgent(LPCWSTR userAgent) = 0;
 
 	virtual HRESULT updateBounds(RECT& bounds) = 0;

--- a/windows/webview_win_floating_plugin.cpp
+++ b/windows/webview_win_floating_plugin.cpp
@@ -221,6 +221,10 @@ void WebviewWinFloatingPlugin::HandleMethodCall(
     auto isEnable = std::get<bool>(arguments[flutter::EncodableValue("isEnable")]);
     webview->enableJavascript(isEnable);
     result->Success(flutter::EncodableValue(true));
+  } else if (method_call.method_name().compare("enableStatusBar") == 0) {
+       auto isEnable = std::get<bool>(arguments[flutter::EncodableValue("isEnable")]);
+       webview->enableStatusBar(isEnable);
+       result->Success(flutter::EncodableValue(true));
   } else if (method_call.method_name().compare("setUserAgent") == 0) {
     auto userAgent = std::get<std::string>(arguments[flutter::EncodableValue("userAgent")]);
     HRESULT hr = webview->setUserAgent(toWideString(userAgent));


### PR DESCRIPTION
By default, the webview in Windows enables the status bar. When hovering over a link, the status bar appears in the left-bottom corner of the window. This is annoying because it makes the app feel more like a webpage rather than a native application. With setStatusBar, developers can hide the status bar, making the app feel closer to a native application.

See more info about the [status bar](https://learn.microsoft.com/en-us/dotnet/api/microsoft.web.webview2.core.corewebview2settings.isstatusbarenabled).