### PR TITLE
Implement enableZoom method

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ myChannelName.postMessage("This message is from javascript");
 - controller.canGoForward()
 - controller.currentUrl()
 - controller.clearCache()
+- controller.enableZoom()
 
 ## dispose controller (cleanup webview instance)
 

--- a/lib/webview_plugin.dart
+++ b/lib/webview_plugin.dart
@@ -276,10 +276,6 @@ class WindowsPlatformWebViewController extends PlatformWebViewController {
     return controller.setBackgroundColor(color);
   }
 
-  @override
-  Future<void> enableZoom(bool isEnable) {
-    return controller.enableZoom(isEnable);
-  }
 
   Future<void> openDevTools() {
     return controller.openDevTools();
@@ -287,6 +283,11 @@ class WindowsPlatformWebViewController extends PlatformWebViewController {
 
   Future<void> setStatusBar(bool isEnable) {
     return controller.setStatusBar(isEnable);
+  }
+
+  @override
+  Future<void> enableZoom(bool isEnable) {
+    return controller.enableZoom(isEnable);
   }
 
 }

--- a/lib/webview_plugin.dart
+++ b/lib/webview_plugin.dart
@@ -276,6 +276,11 @@ class WindowsPlatformWebViewController extends PlatformWebViewController {
     return controller.setBackgroundColor(color);
   }
 
+  @override
+  Future<void> enableZoom(bool isEnable) {
+    return controller.enableZoom(isEnable);
+  }
+
   Future<void> openDevTools() {
     return controller.openDevTools();
   }
@@ -283,6 +288,7 @@ class WindowsPlatformWebViewController extends PlatformWebViewController {
   Future<void> setStatusBar(bool isEnable) {
     return controller.setStatusBar(isEnable);
   }
+
 }
 
 // --------------------------------------------------------------------------

--- a/lib/webview_win_floating.dart
+++ b/lib/webview_win_floating.dart
@@ -151,6 +151,12 @@ class WinWebViewController {
         .enableStatusBar(_webviewId, isEnable);
   }
 
+  Future<void> enableZoom(bool isEnable) async {
+    await _initFuture;
+    await WebviewWinFloatingPlatform.instance
+        .enableZoom(_webviewId, isEnable);
+  }
+
   Future<void> addJavaScriptChannel(String name,
       {required JavaScriptMessageCallback callback}) async {
     bool isExists = _javaScriptMessageCallbacks.containsKey(name);

--- a/lib/webview_win_floating_method_channel.dart
+++ b/lib/webview_win_floating_method_channel.dart
@@ -178,6 +178,12 @@ class MethodChannelWebviewWinFloating extends WebviewWinFloatingPlatform {
   }
 
   @override
+  Future<void> enableZoom(int webviewId, bool isEnable) async {
+    await methodChannel.invokeMethod<bool>(
+        'enableIsZoomControl', {"webviewId": webviewId, "isEnable": isEnable});
+  }
+
+  @override
   Future<bool> setUserAgent(int webviewId, String userAgent) async {
     bool? b = await methodChannel.invokeMethod<bool?>(
         'setUserAgent', {"webviewId": webviewId, "userAgent": userAgent});

--- a/lib/webview_win_floating_platform_interface.dart
+++ b/lib/webview_win_floating_platform_interface.dart
@@ -90,6 +90,10 @@ abstract class WebviewWinFloatingPlatform extends PlatformInterface {
     throw UnimplementedError();
   }
 
+  Future<void> enableZoom(int webviewId, bool isEnable) {
+    throw UnimplementedError();
+  }
+
   Future<bool> setUserAgent(int webviewId, String userAgent) {
     throw UnimplementedError();
   }

--- a/windows/my_webview.cpp
+++ b/windows/my_webview.cpp
@@ -63,6 +63,8 @@ public:
 
     void enableStatusBar(bool bEnable);
 
+    void enableIsZoomControl(bool bEnable);
+
     HRESULT setUserAgent(LPCWSTR userAgent);
 
     HRESULT updateBounds(RECT& bounds);
@@ -452,6 +454,11 @@ void MyWebViewImpl::enableJavascript(bool bEnable)
 void MyWebViewImpl::enableStatusBar(bool bEnable)
 {
     m_pSettings->put_IsStatusBarEnabled(bEnable);
+}
+
+void MyWebViewImpl::enableIsZoomControl(bool bEnable)
+{
+    m_pSettings->put_IsZoomControlEnabled(bEnable);
 }
 
 HRESULT MyWebViewImpl::setUserAgent(LPCWSTR userAgent)

--- a/windows/my_webview.h
+++ b/windows/my_webview.h
@@ -37,6 +37,7 @@ public:
 
 	virtual void enableJavascript(bool bEnable) = 0;
 	virtual void enableStatusBar(bool bEnable) = 0;
+	virtual void enableIsZoomControl(bool bEnable) = 0;
 
 	virtual HRESULT setUserAgent(LPCWSTR userAgent) = 0;
 

--- a/windows/webview_win_floating_plugin.cpp
+++ b/windows/webview_win_floating_plugin.cpp
@@ -225,6 +225,10 @@ void WebviewWinFloatingPlugin::HandleMethodCall(
        auto isEnable = std::get<bool>(arguments[flutter::EncodableValue("isEnable")]);
        webview->enableStatusBar(isEnable);
        result->Success(flutter::EncodableValue(true));
+  } else if (method_call.method_name().compare("enableIsZoomControl") == 0) {
+         auto isEnable = std::get<bool>(arguments[flutter::EncodableValue("isEnable")]);
+         webview->enableIsZoomControl(isEnable);
+         result->Success(flutter::EncodableValue(true));
   } else if (method_call.method_name().compare("setUserAgent") == 0) {
     auto userAgent = std::get<std::string>(arguments[flutter::EncodableValue("userAgent")]);
     HRESULT hr = webview->setUserAgent(toWideString(userAgent));


### PR DESCRIPTION
Implement [`enableZoom`](https://pub.dev/documentation/webview_flutter/latest/webview_flutter/WebViewController/enableZoom.html) method on windows like other platforms.

It's a bit strange that windows allows zooming in webview by default. With enableZoom, developers now can disable that.