### PR TITLE
Add captureScreenshot method

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,7 @@ There are some Windows-only API:
 * onHistoryChanged` callback in WinNavigationDelegate
 * controller.dispose()
 * controller.setStatusBar(bool isEnable): show/hide [status bar](https://learn.microsoft.com/en-us/dotnet/api/microsoft.web.webview2.core.corewebview2settings.isstatusbarenabled)
+* controller.captureScreenshot()
 
 
 # TroubleShooting

--- a/lib/webview_plugin.dart
+++ b/lib/webview_plugin.dart
@@ -1,4 +1,5 @@
 import 'dart:developer';
+import 'dart:typed_data';
 
 import 'package:flutter/widgets.dart';
 import 'package:webview_flutter_platform_interface/webview_flutter_platform_interface.dart';
@@ -258,6 +259,11 @@ class WindowsPlatformWebViewController extends PlatformWebViewController {
   @override
   Future<void> setUserAgent(String? userAgent) {
     return controller.setUserAgent(userAgent);
+  }
+
+  @override
+  Future<Uint8List> captureScreenshot() {
+    return controller.captureScreenshot();
   }
 
   @override

--- a/lib/webview_win_floating.dart
+++ b/lib/webview_win_floating.dart
@@ -405,6 +405,12 @@ class WinWebViewController {
         .setUserAgent(_webviewId, userAgent);
   }
 
+  Future<Uint8List> captureScreenshot() async {
+    await _initFuture;
+    return await WebviewWinFloatingPlatform.instance
+        .captureScreenshot(_webviewId);
+  }
+
   Future<void> requestFocus() async {
     await _initFuture;
     return await WebviewWinFloatingPlatform.instance.requestFocus(_webviewId);

--- a/lib/webview_win_floating_method_channel.dart
+++ b/lib/webview_win_floating_method_channel.dart
@@ -186,6 +186,12 @@ class MethodChannelWebviewWinFloating extends WebviewWinFloatingPlatform {
   }
 
   @override
+  Future<Uint8List> captureScreenshot(int webviewId) async {
+    return await methodChannel.invokeMethod<Uint8List>(
+      'captureScreenshot', {"webviewId": webviewId}) ?? Uint8List(0);
+  }
+
+  @override
   Future<bool> canGoBack(int webviewId) async {
     bool? b = await methodChannel
         .invokeMethod<bool?>('canGoBack', {"webviewId": webviewId});

--- a/lib/webview_win_floating_platform_interface.dart
+++ b/lib/webview_win_floating_platform_interface.dart
@@ -1,4 +1,5 @@
 import 'dart:ui';
+import 'dart:typed_data';
 
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 
@@ -88,6 +89,10 @@ abstract class WebviewWinFloatingPlatform extends PlatformInterface {
   }
 
   Future<bool> setUserAgent(int webviewId, String userAgent) {
+    throw UnimplementedError();
+  }
+
+  Future<Uint8List> captureScreenshot(int webviewId) {
     throw UnimplementedError();
   }
 

--- a/windows/my_webview.h
+++ b/windows/my_webview.h
@@ -43,6 +43,7 @@ public:
 	virtual void enableIsZoomControl(bool bEnable) = 0;
 
 	virtual HRESULT setUserAgent(LPCWSTR userAgent) = 0;
+	virtual HRESULT captureScreenshot(std::function<void(HRESULT, std::vector<uint8_t>)> callback) = 0;
 
 	virtual HRESULT updateBounds(RECT& bounds) = 0;
 	virtual HRESULT getBounds(RECT& bounds) = 0;

--- a/windows/webview_win_floating_plugin.cpp
+++ b/windows/webview_win_floating_plugin.cpp
@@ -241,6 +241,16 @@ void WebviewWinFloatingPlugin::HandleMethodCall(
     auto userAgent = std::get<std::string>(arguments[flutter::EncodableValue("userAgent")]);
     HRESULT hr = webview->setUserAgent(toWideString(userAgent));
     result->Success(flutter::EncodableValue(SUCCEEDED(hr) ? true : false));
+  } else if (method_call.method_name().compare("captureScreenshot") == 0) {
+    std::shared_ptr<flutter::MethodResult<flutter::EncodableValue>> shared_result = std::move(result);
+    auto hr = webview->captureScreenshot([shared_result](HRESULT hr, std::vector<uint8_t> data) {
+      if (SUCCEEDED(hr)) {
+        shared_result->Success(flutter::EncodableValue(std::move(data)));
+      } else {
+        shared_result->Error("captureScreenshot() error");
+      }
+    });
+    if (FAILED(hr)) result->Error("captureScreenshot() error");
   } else if (method_call.method_name().compare("canGoBack") == 0) {
     bool allow = webview->canGoBack();
     result->Success(flutter::EncodableValue(allow));


### PR DESCRIPTION
This allows developers to programmatically capture the content of the Webview. The image is returned as a `Uint8List` containing JPEG image data and can be further processed as necessary.