### PR TITLE
Fix: Respect userDataFolder to allow multiple isolated environments

### DIFF
--- a/lib/webview_plugin.dart
+++ b/lib/webview_plugin.dart
@@ -137,11 +137,23 @@ typedef WindowsPlatformWebViewControllerCreationParams // legacy name
 class WindowsWebViewControllerCreationParams
     extends PlatformWebViewControllerCreationParams {
   final String? userDataFolder;
+
+  /// Optional profile name for session isolation.
+  ///
+  /// When specified, WebView2 will use a named profile to isolate cookies,
+  /// cache, and storage from other WebView instances, while sharing the same
+  /// underlying browser process (more memory-efficient than separate
+  /// environments). This works like Chrome's user profiles.
+  ///
+  /// See: https://learn.microsoft.com/en-us/microsoft-edge/webview2/concepts/multi-profile-support
+  final String? profileName;
+
   final bool suspendDuringDeactive;
 
   /// Creates a new [WindowsPlatformWebViewControllerCreationParams] instance.
   const WindowsWebViewControllerCreationParams({
     this.userDataFolder,
+    this.profileName,
     this.suspendDuringDeactive = true,
   }) : super();
 

--- a/lib/webview_win_floating.dart
+++ b/lib/webview_win_floating.dart
@@ -251,6 +251,7 @@ class WinWebViewController {
       _webviewId,
       initialUrl: null,
       userDataFolder: this.params.userDataFolder,
+      profileName: this.params.profileName,
     );
   }
 

--- a/lib/webview_win_floating_method_channel.dart
+++ b/lib/webview_win_floating_method_channel.dart
@@ -131,11 +131,13 @@ class MethodChannelWebviewWinFloating extends WebviewWinFloatingPlatform {
     int webviewId, {
     String? initialUrl,
     String? userDataFolder,
+    String? profileName,
   }) async {
     return await methodChannel.invokeMethod<bool>('create', {
           "webviewId": webviewId,
           "url": initialUrl ?? "",
           "userDataFolder": userDataFolder ?? "",
+          "profileName": profileName ?? "",
         }) ??
         false;
   }

--- a/lib/webview_win_floating_platform_interface.dart
+++ b/lib/webview_win_floating_platform_interface.dart
@@ -39,6 +39,7 @@ abstract class WebviewWinFloatingPlatform extends PlatformInterface {
     int webviewId, {
     String? initialUrl,
     String? userDataFolder,
+    String? profileName,
   }) {
     throw UnimplementedError();
   }

--- a/windows/my_webview.cpp
+++ b/windows/my_webview.cpp
@@ -40,7 +40,8 @@ class MyWebViewImpl : public MyWebView
 public:
     MyWebViewImpl(HWND hWnd,
         MyWebViewCreateParams params,
-        PCWSTR pwUserDataFolder);
+        PCWSTR pwUserDataFolder,
+        PCWSTR pwProfileName);
 
     virtual ~MyWebViewImpl() override;
 
@@ -112,32 +113,31 @@ private:
     wil::com_ptr<ICoreWebView2Controller> m_pController;
     wil::com_ptr<ICoreWebView2Settings> m_pSettings;
     RECT m_bounds = { 0,0,0,0 };
-    std::wstring m_folderKey;
 };
-std::map<std::wstring, wil::com_ptr<ICoreWebView2Environment>> g_envs;
+wil::com_ptr<ICoreWebView2Environment> g_env;
 
 // --------------------------------------------------------------------------
 
 MyWebView* MyWebView::Create(HWND hWnd,
     MyWebViewCreateParams params,
-    PCWSTR pwUserDataFolder)
+    PCWSTR pwUserDataFolder,
+    PCWSTR pwProfileName)
 {
-    return new MyWebViewImpl(hWnd, params, pwUserDataFolder);
+    return new MyWebViewImpl(hWnd, params, pwUserDataFolder, pwProfileName);
 }
 
 HRESULT InitWebViewRuntime(PCWSTR pwUserDataFolder, std::function<void(HRESULT)> callback = nullptr)
 {
-    std::wstring folderKey = pwUserDataFolder == nullptr ? L"" : pwUserDataFolder;
-    if (g_envs.find(folderKey) != g_envs.end()) {
+    if (g_env != NULL) {
         if (callback != nullptr) callback(S_OK);
         return S_OK;
     }
 
     return CreateCoreWebView2EnvironmentWithOptions(nullptr, pwUserDataFolder, nullptr,
         Callback<ICoreWebView2CreateCoreWebView2EnvironmentCompletedHandler>(
-            [callback, folderKey](HRESULT result, ICoreWebView2Environment* env) -> HRESULT {
+            [callback](HRESULT result, ICoreWebView2Environment* env) -> HRESULT {
                 if (result == S_OK) {
-                    g_envs[folderKey] = env;
+                    g_env = env;
                 }
                 if (callback != nullptr) callback(result);
                 return result;
@@ -151,16 +151,19 @@ HRESULT ReleaseWebViewRuntime()
 
 MyWebViewImpl::MyWebViewImpl(HWND hWnd,
     MyWebViewCreateParams params,
-    PCWSTR pwUserDataFolder = NULL) : m_params(params)
+    PCWSTR pwUserDataFolder = NULL,
+    PCWSTR pwProfileName = NULL) : m_params(params)
 {
-    m_folderKey = pwUserDataFolder == nullptr ? L"" : pwUserDataFolder;
+    std::wstring profileName = (pwProfileName != NULL) ? pwProfileName : L"";
+
     InitWebViewRuntime(pwUserDataFolder, [=](HRESULT hr) -> void {
         if (hr != S_OK) {
             params.onCreated(hr, NULL);
             return;
         }
 
-        g_envs[m_folderKey]->CreateCoreWebView2Controller(hWnd, Callback<ICoreWebView2CreateCoreWebView2ControllerCompletedHandler>(
+        // Lambda that handles the controller after creation (shared by both paths)
+        auto onControllerCreated = Callback<ICoreWebView2CreateCoreWebView2ControllerCompletedHandler>(
             [=](HRESULT hr, ICoreWebView2Controller* controller) -> HRESULT {
                 if (hr != S_OK) {
                     params.onCreated(hr, NULL);
@@ -420,7 +423,29 @@ MyWebViewImpl::MyWebViewImpl(HWND hWnd,
 
                 params.onCreated(hr, this);
                 return hr;
-            }).Get());
+            });
+
+        // If a profileName is specified, use ICoreWebView2Environment10 to create
+        // a controller with profile-based isolation (shared process, separate sessions).
+        // See: https://learn.microsoft.com/en-us/microsoft-edge/webview2/concepts/multi-profile-support
+        if (!profileName.empty()) {
+            auto env10 = g_env.try_query<ICoreWebView2Environment10>();
+            if (env10 != NULL) {
+                wil::com_ptr<ICoreWebView2ControllerOptions> options;
+                HRESULT optHr = env10->CreateCoreWebView2ControllerOptions(&options);
+                if (SUCCEEDED(optHr) && options != NULL) {
+                    options->put_ProfileName(profileName.c_str());
+                    env10->CreateCoreWebView2ControllerWithOptions(hWnd, options.get(), onControllerCreated.Get());
+                    return;
+                }
+                std::cout << "[webview_win_floating] CreateCoreWebView2ControllerOptions failed, falling back to default controller" << std::endl;
+            } else {
+                std::cout << "[webview_win_floating] ICoreWebView2Environment10 not available, profileName ignored" << std::endl;
+            }
+        }
+
+        // Standard path: no profile name, or profile API unavailable
+        g_env->CreateCoreWebView2Controller(hWnd, onControllerCreated.Get());
         });
 }
 
@@ -458,7 +483,6 @@ void MyWebViewImpl::grantPermission(int deferralId, BOOL isGranted)
 MyWebViewImpl::~MyWebViewImpl()
 {
     m_pController->Close();
-    g_envs.erase(m_folderKey);
     std::cout << "[webview_win_floating] MyWebViewImpl::~MyWebViewImpl()" << std::endl;
 }
 

--- a/windows/my_webview.cpp
+++ b/windows/my_webview.cpp
@@ -112,8 +112,9 @@ private:
     wil::com_ptr<ICoreWebView2Controller> m_pController;
     wil::com_ptr<ICoreWebView2Settings> m_pSettings;
     RECT m_bounds = { 0,0,0,0 };
+    std::wstring m_folderKey;
 };
-wil::com_ptr<ICoreWebView2Environment> g_env;
+std::map<std::wstring, wil::com_ptr<ICoreWebView2Environment>> g_envs;
 
 // --------------------------------------------------------------------------
 
@@ -126,15 +127,18 @@ MyWebView* MyWebView::Create(HWND hWnd,
 
 HRESULT InitWebViewRuntime(PCWSTR pwUserDataFolder, std::function<void(HRESULT)> callback = nullptr)
 {
-    if (g_env != NULL) {
+    std::wstring folderKey = pwUserDataFolder == nullptr ? L"" : pwUserDataFolder;
+    if (g_envs.find(folderKey) != g_envs.end()) {
         if (callback != nullptr) callback(S_OK);
         return S_OK;
     }
 
     return CreateCoreWebView2EnvironmentWithOptions(nullptr, pwUserDataFolder, nullptr,
         Callback<ICoreWebView2CreateCoreWebView2EnvironmentCompletedHandler>(
-            [callback](HRESULT result, ICoreWebView2Environment* env) -> HRESULT {
-                g_env = env;
+            [callback, folderKey](HRESULT result, ICoreWebView2Environment* env) -> HRESULT {
+                if (result == S_OK) {
+                    g_envs[folderKey] = env;
+                }
                 if (callback != nullptr) callback(result);
                 return result;
             }).Get());
@@ -149,13 +153,14 @@ MyWebViewImpl::MyWebViewImpl(HWND hWnd,
     MyWebViewCreateParams params,
     PCWSTR pwUserDataFolder = NULL) : m_params(params)
 {
+    m_folderKey = pwUserDataFolder == nullptr ? L"" : pwUserDataFolder;
     InitWebViewRuntime(pwUserDataFolder, [=](HRESULT hr) -> void {
         if (hr != S_OK) {
             params.onCreated(hr, NULL);
             return;
         }
 
-        g_env->CreateCoreWebView2Controller(hWnd, Callback<ICoreWebView2CreateCoreWebView2ControllerCompletedHandler>(
+        g_envs[m_folderKey]->CreateCoreWebView2Controller(hWnd, Callback<ICoreWebView2CreateCoreWebView2ControllerCompletedHandler>(
             [=](HRESULT hr, ICoreWebView2Controller* controller) -> HRESULT {
                 if (hr != S_OK) {
                     params.onCreated(hr, NULL);
@@ -453,6 +458,7 @@ void MyWebViewImpl::grantPermission(int deferralId, BOOL isGranted)
 MyWebViewImpl::~MyWebViewImpl()
 {
     m_pController->Close();
+    g_envs.erase(m_folderKey);
     std::cout << "[webview_win_floating] MyWebViewImpl::~MyWebViewImpl()" << std::endl;
 }
 

--- a/windows/my_webview.h
+++ b/windows/my_webview.h
@@ -36,7 +36,8 @@ class MyWebView
 public:
 	static MyWebView* Create(HWND hWnd,
 		MyWebViewCreateParams params,
-		PCWSTR pwUserDataFolder = NULL);
+		PCWSTR pwUserDataFolder = NULL,
+		PCWSTR pwProfileName = NULL);
 
 	//MyWebView();
 	virtual ~MyWebView() {};

--- a/windows/webview_win_floating_plugin.cpp
+++ b/windows/webview_win_floating_plugin.cpp
@@ -21,7 +21,7 @@ std::shared_ptr<WCHAR[]> utf8ToUtf16(std::string str8) {
   int arrSize = (int) str8.length() + 1;
   std::shared_ptr<WCHAR[]> str16(new WCHAR[arrSize]);
   auto convResult = MultiByteToWideChar(CP_UTF8, 0, str8.c_str(), -1, str16.get(), arrSize);
-  if (convResult < 0) {
+  if (convResult == 0) {
     std::cout << "[webview_win_floating] native convert tring to utf16 (WCHAR*) failed: str = " << str8 << std::endl;
   }
 
@@ -63,7 +63,7 @@ WebviewWinFloatingPlugin::~WebviewWinFloatingPlugin() {
 
 void WebviewWinFloatingPlugin::createWebview(const flutter::MethodCall<flutter::EncodableValue> &method_call,
     std::unique_ptr<flutter::MethodResult<flutter::EncodableValue>> &result,
-    int webviewId, std::string url, std::string userDataFolder) {
+    int webviewId, std::string url, std::string userDataFolder, std::string profileName) {
 
   std::shared_ptr<flutter::MethodResult<flutter::EncodableValue>> shared_result = std::move(result);
   MyWebViewCreateParams params;
@@ -182,14 +182,25 @@ void WebviewWinFloatingPlugin::createWebview(const flutter::MethodCall<flutter::
   WCHAR wUserDataFolder[1024];
   if (!userDataFolder.empty()) {
     auto convResult = MultiByteToWideChar(CP_UTF8, 0, userDataFolder.c_str(), -1, wUserDataFolder, sizeof(wUserDataFolder) / sizeof(WCHAR));
-    if (convResult < 0) {
+    if (convResult == 0) {
       std::cout << "[webview_win_floating] native convert userDataFolder to utf16 (WCHAR*) failed: path = " << userDataFolder << std::endl;
     } else {
       pwUserDataFolder = wUserDataFolder;
     }
   }
 
-  MyWebView::Create(m_nativeHWND, params, pwUserDataFolder);
+  PCWSTR pwProfileName = NULL;
+  WCHAR wProfileName[256];
+  if (!profileName.empty()) {
+    auto convResult = MultiByteToWideChar(CP_UTF8, 0, profileName.c_str(), -1, wProfileName, sizeof(wProfileName) / sizeof(WCHAR));
+    if (convResult == 0) {
+      std::cout << "[webview_win_floating] native convert profileName to utf16 (WCHAR*) failed: name = " << profileName << std::endl;
+    } else {
+      pwProfileName = wProfileName;
+    }
+  }
+
+  MyWebView::Create(m_nativeHWND, params, pwUserDataFolder, pwProfileName);
 }
 
 void WebviewWinFloatingPlugin::destroyAllWebViews() {
@@ -226,7 +237,8 @@ void WebviewWinFloatingPlugin::HandleMethodCall(
   if (isCreateCall) {
     auto url = std::get<std::string>(arguments[flutter::EncodableValue("url")]);
     auto userDataFolder = std::get<std::string>(arguments[flutter::EncodableValue("userDataFolder")]);
-    createWebview(method_call, result, webviewId, url, userDataFolder);
+    auto profileName = std::get<std::string>(arguments[flutter::EncodableValue("profileName")]);
+    createWebview(method_call, result, webviewId, url, userDataFolder, profileName);
   } else if (method_call.method_name().compare("setHasNavigationDecision") == 0) {
     auto hasNavigationDecision = std::get<bool>(arguments[flutter::EncodableValue("hasNavigationDecision")]);
     webview->setHasNavigationDecision(hasNavigationDecision);

--- a/windows/webview_win_floating_plugin.h
+++ b/windows/webview_win_floating_plugin.h
@@ -40,7 +40,7 @@ class WebviewWinFloatingPlugin : public flutter::Plugin {
 
   void WebviewWinFloatingPlugin::createWebview(const flutter::MethodCall<flutter::EncodableValue> &method_call,
     std::unique_ptr<flutter::MethodResult<flutter::EncodableValue>> &result,
-    int webviewId, std::string url, std::string userDataFolder);
+    int webviewId, std::string url, std::string userDataFolder, std::string profileName);
   void destroyAllWebViews();
   // Jacky }
 };


### PR DESCRIPTION
I use this package for a Flutter [project ](https://github.com/Faeq-F/whatsappPortable/) where I need to run multiple `WebViewWidget` instances simultaneously, each logged into different accounts (for [this feature](https://github.com/Faeq-F/whatsappPortable/issues/1)). I passed a unique `userDataFolder` to each widget to isolate their sessions (cookies, cache, etc.). However, I found that all instances were still sharing the exact same session.

My AI coding assistant helped me debug this and discovered that the native Windows C++ code was using a single, globally shared `g_env` pointer for the `ICoreWebView2Environment`. This forced every new WebView to piggyback off the very first environment, ignoring the custom `userDataFolder` paths passed from the Dart code.

**What this PR does:**

Makes the global `g_env` variable a dictionary (`std::map<std::wstring, wil::com_ptr<ICoreWebView2Environment>> g_envs;`) keyed by the `userDataFolder` string.

When a new WebView is created, the code now checks the map. If an environment for that specific folder exists, it reuses it. If not, it creates a new, completely isolated environment.

Updates `~MyWebViewImpl()` to erase its environment from the map upon disposal. This ensures the COM pointer is released and Windows file locks are freed, allowing developers to safely delete the data folder immediately after disposing the widget.

*Note:* I am a novice Flutter / Dart developer and haven't written C++ before. This C++ fix was 100% written by an AI assistant, but I have user-tested the code locally in my own app.